### PR TITLE
Prioritize items based on how far an item needs to travel

### DIFF
--- a/types.lua
+++ b/types.lua
@@ -15,10 +15,9 @@
 --- @field knownFromOtherItem boolean
 --- @field requiresUpgrade boolean
 --- @field requiresCatalyse boolean
---- @field requiresCatalyseUpgrade boolean
 --- @field itemLink string
 --- @field location string
---- @field sortPriority number # higher numbers should be sorted first
+--- @field distance number # 0 = same character, 100+ = warband bank, 1000 = different character.
 
 --- @class TUM_AppearanceMissingResult
 --- @field canCatalyse boolean? # whether the item can be catalysed; if false, the catalystAppearanceMissing values will be nil


### PR DESCRIPTION
The intention of this change is to make it easier to verify at a glance whether an item is available for catalysing later. A warband item sitting on another character might be committed to that specific character, and so should be considered a lower priority for other characters.

With this commit, items in the TUM Collections UI tooltip are first ordered according to this priority:

 1. Catalyse
 2. Upgrade
 3. Upgrade & Catalyse

which matches the priority of how the Catalyse and Upgrade icons are aggregated into Collections table.

Within the tooltips, items are then ordered according to "distance", which tracks how far the item has to travel to be catalysed:

 1. (Zero distance) Item is on a character of the same class as the tier appearance under consideration.
 2. Item is in the warband bank.
 3. (Maximum distance) Item is on a character of a different class from the tier appearance under consideration.

A warband icon has been added to indicate whether the item needs to travel. This icon is also shown in the Collections table.

## Examples

<img width="609" height="205" alt="Tooltip where all items require travel." src="https://github.com/user-attachments/assets/a61b7005-1571-447b-8556-ffe1c8c54a5c" />

<img width="465" height="154" alt="Tooltip where some items require travel." src="https://github.com/user-attachments/assets/1406aaf4-6ba4-4305-9e84-0e8c86ea4fdf" />